### PR TITLE
Add Travis Build Script for Continous Delivery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     # we're copying over the template files into the renpy SDK
     # and CD into the renpy
     
-    - bash ./quickstart-travis/setup.sh
+    - bash ./the-angel-returns/setup.sh
     
     # Remove README.html to prevent errors.
     - rm -rf the-angel-returns/README.html && cp -vRf the-angel-returns/* mod/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+language: python
+python:
+    - "2.7"
+
+sudo: required
+
+# Travis build script for RenPy
+# based on Monika-After-Story script.
+  
+# This is the install stage
+# All your dependencies go here. We have done the RenPy SDK part done for you.
+
+install:
+    - cd ..
+    - wget https://www.renpy.org/dl/6.99.12.4/renpy-6.99.12.4-sdk.tar.bz2
+    - tar xf renpy-6.99.12.4-sdk.tar.bz2
+    - rm renpy-6.99.12.4-sdk.tar.bz2
+    - mv renpy-6.99.12.4-sdk renpy
+
+    # now this is where it gets interesting
+    # we're copying over the template files into the renpy SDK
+    # and CD into the renpy
+    
+    - bash ./quickstart-travis/setup.sh
+    
+    # Remove README.html to prevent errors.
+    - rm -rf the-angel-returns/README.html && cp -vRf the-angel-returns/* mod/
+    
+    - cd renpy
+
+
+env:
+    # this is required as there was build issues without this, don't remove this.
+    - SDL_AUDIODRIVER=dummy SDL_VIDEODRIVER=dummy
+
+# This is the script part. This is where the actual building is happening.
+# This produces an artifact which we'll use later on to publish a release.
+
+script: ./renpy.sh "../mod/" lint && ./renpy.sh launcher distribute "../mod/" && cd ..
+
+
+# This is where the actual releases happen. Travis has the ability to publish releases from GitHub, Amazon S3, OpenShift, etc.
+# Read on https://docs.travis-ci.com/user/deployment/releases/ to learn more
+# For this type of configuration, we're using the GitHub releases schema
+
+deploy:
+  provider: releases
+  api_key:
+    # DO NOT CHANGE THIS! Travis can replace this since it's a Environment Variable.
+    # Head to Settings > Environment variables and set this.
+    secure: $GITHUB_API_KEY
+  file_glob: true
+  file: "*-dists/**"
+  skip_cleanup: true
+  on:
+    tags: true # your mods only builds and uploads releases on a GitHub Git tag so make sure you tag and release accordingly!

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# config for mc
+# If you have your own base files, kindly edit this
+# However, if you prefer our base files, that's okay too!
+
+mc_endpoint="https://s3-api.us-geo.objectstorage.softlayer.net"
+mc_hmac_key="aa1d6f56b97443c185d7282c22adc4a7"
+mc_hmac_secret="29fc312082d26720ceeec6e89630f6d2fc382a96c7a72b1c"
+mc_alias="ibm"
+mc_bucket="filepub"
+mc_filename="ddlc_pkg.zip"
+
+# DO NOT EDIT BELOW THIS LINE
+# This is intended for automating unzipping and putting the RPAs into the respect folder
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Installing Minio S3 Client"
+
+wget "https://dl.minio.io/client/mc/release/linux-amd64/mc" && \
+
+chmod +x mc && \
+
+sudo cp -vR mc /usr/bin/mc && \
+
+mc config host add $mc_alias $mc_endpoint $mc_hmac_key $mc_hmac_secret && \
+
+# try if it works
+
+mc ls $mc_alias;
+
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Checking for dir if it exists"
+
+if [ -d "./mod" ]; then
+    # dir exists, just unzip, and make new dir to add files
+    echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Directory exists. Creating game/ subdir and copying files over."
+    mc cp "$mc_alias/$mc_bucket/$mc_filename" ./
+    mkdir -p "./mod/game"
+    unzip $mc_filename -d  mod/game 
+    exit 0
+  else 
+    echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Directory  does not exist. Creating dir and copying files over" 
+    mkdir -p mod
+    mc cp "$mc_alias/$mc_bucket/$mc_filename" ./
+    mkdir -p "./mod/game"
+    unzip $mc_filename -d  mod/game    
+    exit 0 
+fi


### PR DESCRIPTION
Hi, Sayonika here!

I picked you as our sample mod to test the scripts for CI/CD for mods, and today I'm glad to give this in GA form. I customized this in consideration of your project's structure and it works p well now.

Here's some notes however:

- Please add your API key in Travis as ``GITHUB_API_KEY``. This can be done using Settings > Environment Variables.

- API keys can be created from the developer settings of GitHub on the Settings page. Give it the `repo` scope.

That's all, Happy coding!

~ Sayonika